### PR TITLE
funcoes para mudar as varieveis de ambiente OLD_PWD e PWD quando se executa o comando cd

### DIFF
--- a/change_env_vars.c
+++ b/change_env_vars.c
@@ -1,0 +1,79 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   change_env_vars.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: gkomba <marvin@42.fr>                      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/10/31 12:05:18 by gkomba            #+#    #+#             */
+/*   Updated: 2024/10/31 12:21:20 by gkomba           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	increment_shell_level(t_minishell *minishell)
+{
+	char	**prompt;
+	char	*shell_level;
+	char	*name;
+	int		level;
+
+	shell_level = getenv("SHLVL");
+	name = NULL;
+	prompt =(char **)malloc(sizeof(char *) * 3);
+    ft_memset(prompt, 0, sizeof(char *) * 3);
+	prompt[0] = "export";
+	prompt[2] = 0;
+	if (shell_level)
+	{
+		name = "SHLVL=";
+		level = ft_atoi(shell_level);
+		level++;
+		shell_level = ft_itoa(level);
+		name = ft_strjoin(name, shell_level);
+		prompt[1] = name;
+		command_export(prompt, 0, minishell);
+		free(shell_level);
+		free(name);
+	}
+	else
+	{
+		name = "SHLVL=1";
+		prompt[1] = name;
+		command_export(prompt, 0, minishell);	
+	}
+    free(prompt);
+}
+
+void    change_pwd(char *curr_pwd, t_minishell *minishell)
+{
+    char    **prompt;
+    char    *name;
+
+    prompt = (char **)malloc(sizeof(char *) * 3);
+    ft_memset(prompt, 0, sizeof(char *) * 3);
+    prompt[0] = "export";
+    prompt[2] = 0;
+    name = ft_strjoin("PWD=", curr_pwd);
+    prompt[1] = name;
+    command_export(prompt, 0, minishell);
+    free(name);
+    free(prompt);
+}
+
+void    change_old_pwd(char *old_pwd, t_minishell *minishell)
+{
+    char    **prompt;
+    char    *name;
+
+    prompt = (char **)malloc(sizeof(char *) * 3);
+    ft_memset(prompt, 0, sizeof(char *) * 3);
+    prompt[0] = "export";
+    prompt[2] = 0;
+    name = ft_strjoin("OLDPWD=", old_pwd);
+    prompt[1] = name;
+    command_export(prompt, 0, minishell);
+    free(name);
+    free(prompt);
+}

--- a/command/cd.c
+++ b/command/cd.c
@@ -6,7 +6,7 @@
 /*   By: gkomba <marvin@42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/19 16:20:47 by gkomba            #+#    #+#             */
-/*   Updated: 2024/10/19 16:22:00 by gkomba           ###   ########.fr       */
+/*   Updated: 2024/10/31 12:14:08 by gkomba           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,13 +14,20 @@
 
 int	command_cd(char **prompt, t_minishell *minishell)
 {
+	char 	*wdir;
+
 	if (prompt[1])
 	{
+		wdir = getenv("PWD");
+		change_old_pwd(wdir, minishell);
 		if (chdir(prompt[1]) != 0)
 		{
 			perror("cd error");
 			return (1);
 		}
+		wdir = getcwd(NULL, 0);
+		change_pwd(wdir, minishell);
+		wdir = free_ptr(wdir);
 	}
 	return (0);
 }

--- a/makefile
+++ b/makefile
@@ -9,6 +9,9 @@ ${NAME}:
 
 clean:
 	make clean -C ${LIBFT}
+
+fclean: clean
+	make fclean -C ${LIBFT}
 	rm -f ${NAME}
 
-re: clean all
+re: fclean all

--- a/minishell.h
+++ b/minishell.h
@@ -91,4 +91,6 @@ char	*trim_quotes(char *tmp);
 int		unbalanced_quotes(char *str);
 void	set_to_env(char *value);
 void	increment_shell_level(t_minishell *minishell);
+void	change_pwd(char *curr_pwd, t_minishell *minishell);
+void	change_old_pwd(char *old_pwd, t_minishell *minishell);
 #endif

--- a/util.c
+++ b/util.c
@@ -6,7 +6,7 @@
 /*   By: gkomba <marvin@42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/19 16:24:38 by gkomba            #+#    #+#             */
-/*   Updated: 2024/10/31 11:26:34 by gkomba           ###   ########.fr       */
+/*   Updated: 2024/10/31 12:05:49 by gkomba           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -226,37 +226,4 @@ char	**net_args(char *prompt)
 		return (data);
 	}
 	return (NULL);
-}
-
-void	increment_shell_level(t_minishell *minishell)
-{
-	char	**prompt;
-	char	*shell_level;
-	char	*name;
-	int		level;
-
-	shell_level = getenv("SHLVL");
-	name = NULL;
-	prompt =(char **)malloc(sizeof(char *) * 3);
-	prompt[0] = "export";
-	prompt[2] = 0;
-	if (shell_level)
-	{
-		name = "SHLVL=";
-		level = ft_atoi(shell_level);
-		level++;
-		shell_level = ft_itoa(level);
-		name = ft_strjoin(name, shell_level);
-		prompt[1] = name;
-		command_export(prompt, 0, minishell);
-		free(shell_level);
-		free(name);
-	}
-	else
-	{
-		name = "SHLVL=1";
-		prompt[1] = name;
-		
-		command_export((char *[]){ "export", "SHLVL=", "1", NULL}, 0, minishell);
-	}
 }


### PR DESCRIPTION
novo arquivo que contem as funcoes que auxiliam na mundanca de algumas variaves de ambientes herdadas do shell antigo.

increment_shell_level funcao que munda o valor da variavel de ambiente SHLVL quando se inicia o minishell.

change_old_pwd funcao que munda o valor da variavel de ambiente OLD_PWD quando se executa o comando cd.

change_pwd funcao que muda o valor da variavel de ambiente PWD quando se executa o comando cd.